### PR TITLE
perf: optimize shared-kernel-rs utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+## [Unreleased]
+
+### Performance
+
+- **redis/error**: Return `&'static str` from `code()` instead of allocating a `String` on every error
+- **redis/error**: Consolidate match arms in `message()` using `|` to eliminate repeated `format!` calls
+- **redis/error**: Clone inner strings directly instead of going through `.to_string()` indirection
+- **redis/error**: Add `#[inline]` hints on `error_message()`, `message()`, `code()`, `error_response()`, `status_code()`
+- **redis/types**: Use struct literal for `PerformanceConfig` instead of default + mutation
+- **redis/types**: Add `#[inline]` on `Deref` impl for `RedisClient`
+- **callapi**: Return `&'static str` from `code()` instead of allocating a `String` on every error
+- **callapi**: Add `#[inline]` hints on error and response methods
+- **callapi**: Use `unwrap_or_else` with `to_owned()` instead of `unwrap_or` with `to_string()`
+- **middleware/utils**: Compile UUID regex once via `once_cell::sync::Lazy` instead of per-request
+- **middleware/utils**: Accept `&str` in `calculate_metrics` instead of taking ownership of `String` args
+- **middleware/utils**: Add `#[inline]` on `get_method()` and `get_headers()`
+- **middleware/incoming_request**: Extract headers/method/path into locals before passing by reference
+- **prometheus**: Use `unwrap_or_else` with `to_owned()` in `incoming_api!` and `termination!` macros
+- **logger**: Avoid unnecessary `.to_string()` on `concat!` macro result (already `&'static str`)
+- **aws**: Replace `.to_owned()` on cloned response contents; use `to_owned()` over `to_string()` for `&str`
+- **ErrorBody** (redis, callapi): Add `#[serde(skip_serializing_if = "String::is_empty")]` to skip empty fields during serialization
+
+### Fixed
+
+- **macros**: `measure_duration` proc macro now preserves function attributes (`#[allow(...)]`, `#[cfg(...)]`, etc.)
+- **redis/commands**: Add explicit `RedisValue` type annotation on `pipeline.all()` and `xadd` calls to resolve type inference
+- **redis/commands**: Use `.first()` instead of `.get(0)` (Clippy `first` lint)
+
+### Changed
+
+- **aws**: Use `aws_config::defaults(BehaviorVersion::latest())` instead of deprecated `aws_config::from_env()`
+- **callapi**: Extract `ErrorHandler<E>` type alias for the boxed error handler function pointer
+- **cloud_storage**: Add `#[allow(clippy::should_implement_trait)]` on deprecated `from_str` method
+
+### Removed
+
+- **redis/types**: Remove unused imports (`log::info`, `tracing::*`, `UnboundedReceiver`, `UnboundedSender`)
+
+### Added
+
+- **benchmarks**: Add criterion benchmarks for serialization patterns (`serialization.rs`)
+- **benchmarks**: Add criterion benchmarks for middleware path normalization (`utils.rs`)
+- **benchmarks**: Add criterion benchmarks for Redis operation patterns (`redis_patterns.rs`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
  "getrandom 0.2.12",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -302,6 +302,18 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
@@ -868,7 +880,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -962,6 +974,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1021,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1057,31 @@ dependencies = [
  "libc",
  "libloading",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -1135,10 +1205,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1157,6 +1282,12 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1722,6 +1853,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy 0.8.27",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,6 +1900,12 @@ name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2152,10 +2300,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2482,6 +2650,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl"
 version = "0.10.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2670,6 +2844,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2779,6 +2981,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.12",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3068,6 +3290,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3245,6 +3476,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-types",
  "chrono",
+ "criterion",
  "error-stack",
  "fred",
  "futures",
@@ -3552,6 +3784,16 @@ checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3893,6 +4135,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4032,6 +4284,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -4313,7 +4574,16 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.32",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive 0.8.27",
 ]
 
 [[package]]
@@ -4321,6 +4591,17 @@ name = "zerocopy-derive"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -20,9 +20,11 @@ pub fn measure_duration(_: TokenStream, input: TokenStream) -> TokenStream {
     let generics = &input_fn.sig.generics;
     let where_clause = &input_fn.sig.generics.where_clause;
     let is_async = input_fn.sig.asyncness.is_some();
+    let attrs = &input_fn.attrs;
 
     let expanded = if is_async {
         quote! {
+            #(#attrs)*
             pub async fn #fn_name #generics(#args) #return_type #where_clause {
                 let start_time = std::time::Instant::now();
                 let result = #function_body;
@@ -35,6 +37,7 @@ pub fn measure_duration(_: TokenStream, input: TokenStream) -> TokenStream {
         }
     } else {
         quote! {
+            #(#attrs)*
             pub fn #fn_name #generics(#args) #return_type #where_clause {
                 let start_time = std::time::Instant::now();
                 let result = #function_body;

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -37,3 +37,23 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 macros = { version = "0.1.0", path = "../macros" }
 aws-config = "1.6.1"
 google-cloud-storage = "0.15"
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+serde = { version = "1.0.155", features = ["derive"] }
+serde_json = "1.0.100"
+regex = "1.10.3"
+urlencoding = "2.1"
+once_cell = "1.17.1"
+
+[[bench]]
+name = "serialization"
+harness = false
+
+[[bench]]
+name = "utils"
+harness = false
+
+[[bench]]
+name = "redis_patterns"
+harness = false

--- a/crates/shared/benches/redis_patterns.rs
+++ b/crates/shared/benches/redis_patterns.rs
@@ -1,0 +1,349 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// Types representing the data flowing through Redis commands.
+// These mirror the actual domain objects serialized/deserialized in commands.rs.
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GeoPoint {
+    lat: f64,
+    lon: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DriverProfile {
+    id: String,
+    name: String,
+    phone: String,
+    vehicle_number: String,
+    rating: f64,
+    total_rides: u64,
+    active: bool,
+    last_location: GeoPoint,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StreamEntry {
+    id: String,
+    timestamp: i64,
+    event_type: String,
+    payload: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RideEstimate {
+    ride_id: String,
+    distance_km: f64,
+    duration_min: f64,
+    fare: f64,
+    surge_multiplier: f64,
+    vehicle_type: String,
+}
+
+fn sample_driver_profile() -> DriverProfile {
+    DriverProfile {
+        id: "driver-550e8400-e29b-41d4-a716-446655440000".to_string(),
+        name: "John Doe".to_string(),
+        phone: "+919876543210".to_string(),
+        vehicle_number: "KA01AB1234".to_string(),
+        rating: 4.8,
+        total_rides: 1250,
+        active: true,
+        last_location: GeoPoint {
+            lat: 12.9716,
+            lon: 77.5946,
+        },
+    }
+}
+
+fn sample_stream_entry() -> StreamEntry {
+    let mut payload = HashMap::new();
+    payload.insert("ride_id".to_string(), "ride-123".to_string());
+    payload.insert("driver_id".to_string(), "driver-456".to_string());
+    payload.insert("status".to_string(), "ACCEPTED".to_string());
+    payload.insert("fare".to_string(), "250.00".to_string());
+    StreamEntry {
+        id: "1700000000-0".to_string(),
+        timestamp: 1700000000,
+        event_type: "ride_update".to_string(),
+        payload,
+    }
+}
+
+fn sample_ride_estimate() -> RideEstimate {
+    RideEstimate {
+        ride_id: "ride-550e8400-e29b-41d4-a716-446655440000".to_string(),
+        distance_km: 12.5,
+        duration_min: 25.0,
+        fare: 250.0,
+        surge_multiplier: 1.2,
+        vehicle_type: "SEDAN".to_string(),
+    }
+}
+
+/// Benchmarks the set_key serialization pipeline:
+/// value -> serde_json::to_string -> String (fed into RedisValue)
+fn bench_set_key_pattern(c: &mut Criterion) {
+    let mut group = c.benchmark_group("redis_set_key");
+
+    let profile = sample_driver_profile();
+    group.bench_function("driver_profile", |b| {
+        b.iter(|| serde_json::to_string(black_box(&profile)))
+    });
+
+    let point = GeoPoint {
+        lat: 12.9716,
+        lon: 77.5946,
+    };
+    group.bench_function("geo_point", |b| {
+        b.iter(|| serde_json::to_string(black_box(&point)))
+    });
+
+    let estimate = sample_ride_estimate();
+    group.bench_function("ride_estimate", |b| {
+        b.iter(|| serde_json::to_string(black_box(&estimate)))
+    });
+
+    group.finish();
+}
+
+/// Benchmarks the get_key deserialization pipeline:
+/// String (from RedisValue) -> serde_json::from_str -> T
+fn bench_get_key_pattern(c: &mut Criterion) {
+    let mut group = c.benchmark_group("redis_get_key");
+
+    let profile_json = serde_json::to_string(&sample_driver_profile()).unwrap();
+    group.bench_function("driver_profile", |b| {
+        b.iter(|| serde_json::from_str::<DriverProfile>(black_box(&profile_json)))
+    });
+
+    let point_json = r#"{"lat":12.9716,"lon":77.5946}"#;
+    group.bench_function("geo_point", |b| {
+        b.iter(|| serde_json::from_str::<GeoPoint>(black_box(point_json)))
+    });
+
+    let estimate_json = serde_json::to_string(&sample_ride_estimate()).unwrap();
+    group.bench_function("ride_estimate", |b| {
+        b.iter(|| serde_json::from_str::<RideEstimate>(black_box(&estimate_json)))
+    });
+
+    group.finish();
+}
+
+/// Benchmarks hash field operations:
+/// set_hash_fields serializes each field, get_all_hash_fields deserializes the map.
+fn bench_hash_operations(c: &mut Criterion) {
+    let mut group = c.benchmark_group("redis_hash");
+
+    // Serializing individual hash field values (set_hash_fields pattern)
+    let field_values: Vec<(&str, &str)> = vec![
+        ("name", "John Doe"),
+        ("phone", "+919876543210"),
+        ("vehicle", "KA01AB1234"),
+        ("rating", "4.8"),
+        ("active", "true"),
+    ];
+    group.bench_function("serialize_5_fields", |b| {
+        b.iter(|| {
+            black_box(&field_values)
+                .iter()
+                .map(|(_, v)| serde_json::to_string(v).unwrap())
+                .collect::<Vec<_>>()
+        })
+    });
+
+    // Deserializing a HashMap response (get_all_hash_fields pattern)
+    let mut hash_data = HashMap::new();
+    hash_data.insert("name".to_string(), "\"John Doe\"".to_string());
+    hash_data.insert("phone".to_string(), "\"+919876543210\"".to_string());
+    hash_data.insert("vehicle".to_string(), "\"KA01AB1234\"".to_string());
+    hash_data.insert("rating".to_string(), "4.8".to_string());
+    hash_data.insert("active".to_string(), "true".to_string());
+    let hash_json = serde_json::to_string(&hash_data).unwrap();
+
+    group.bench_function("deserialize_hash_map", |b| {
+        b.iter(|| serde_json::from_str::<HashMap<String, String>>(black_box(&hash_json)))
+    });
+
+    // FxHashMap construction from deserialized data (used internally)
+    group.bench_function("build_fxhashmap_5_entries", |b| {
+        b.iter(|| {
+            let mut map = rustc_hash::FxHashMap::default();
+            for (k, v) in black_box(&field_values) {
+                map.insert(k.to_string(), v.to_string());
+            }
+            map
+        })
+    });
+
+    group.finish();
+}
+
+/// Benchmarks geo operations (geo_add, geo_search serialization patterns).
+fn bench_geo_operations(c: &mut Criterion) {
+    let mut group = c.benchmark_group("redis_geo");
+
+    // Batch geo point serialization (geo_add with multiple points)
+    for count in [5, 20, 50] {
+        let points: Vec<GeoPoint> = (0..count)
+            .map(|i| GeoPoint {
+                lat: 12.9 + (i as f64 * 0.01),
+                lon: 77.5 + (i as f64 * 0.01),
+            })
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("serialize_batch", count),
+            &points,
+            |b, pts| {
+                b.iter(|| {
+                    pts.iter()
+                        .map(|p| serde_json::to_string(black_box(p)))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+            },
+        );
+    }
+
+    // Batch geo point deserialization (geo_search results)
+    for count in [5, 20, 50] {
+        let json_points: Vec<String> = (0..count)
+            .map(|i| {
+                format!(
+                    r#"{{"lat":{},"lon":{}}}"#,
+                    12.9 + (i as f64 * 0.01),
+                    77.5 + (i as f64 * 0.01)
+                )
+            })
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("deserialize_batch", count),
+            &json_points,
+            |b, jsons| {
+                b.iter(|| {
+                    jsons
+                        .iter()
+                        .map(|s| serde_json::from_str::<GeoPoint>(black_box(s)))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmarks stream entry operations (xadd, xread serialization patterns).
+fn bench_stream_operations(c: &mut Criterion) {
+    let mut group = c.benchmark_group("redis_stream");
+
+    // Single stream entry serialization (xadd)
+    let entry = sample_stream_entry();
+    group.bench_function("serialize_entry", |b| {
+        b.iter(|| serde_json::to_string(black_box(&entry)))
+    });
+
+    // Single stream entry deserialization (xread)
+    let entry_json = serde_json::to_string(&sample_stream_entry()).unwrap();
+    group.bench_function("deserialize_entry", |b| {
+        b.iter(|| serde_json::from_str::<StreamEntry>(black_box(&entry_json)))
+    });
+
+    // Batch stream read (xread with multiple entries)
+    for count in [10, 50] {
+        let entries_json: Vec<String> = (0..count)
+            .map(|i| {
+                let mut payload = HashMap::new();
+                payload.insert("ride_id".to_string(), format!("ride-{i}"));
+                payload.insert("status".to_string(), "ACTIVE".to_string());
+                serde_json::to_string(&StreamEntry {
+                    id: format!("{}-0", 1700000000 + i),
+                    timestamp: 1700000000 + i,
+                    event_type: "ride_update".to_string(),
+                    payload,
+                })
+                .unwrap()
+            })
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("deserialize_batch", count),
+            &entries_json,
+            |b, jsons| {
+                b.iter(|| {
+                    jsons
+                        .iter()
+                        .map(|s| serde_json::from_str::<StreamEntry>(black_box(s)))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmarks the sorted set value serialization pattern (zadd/zrange).
+fn bench_sorted_set_operations(c: &mut Criterion) {
+    let mut group = c.benchmark_group("redis_sorted_set");
+
+    // Serialize ride estimates as sorted set members
+    for count in [5, 20] {
+        let estimates: Vec<RideEstimate> = (0..count)
+            .map(|i| RideEstimate {
+                ride_id: format!("ride-{i}"),
+                distance_km: 5.0 + (i as f64 * 2.0),
+                duration_min: 10.0 + (i as f64 * 5.0),
+                fare: 100.0 + (i as f64 * 50.0),
+                surge_multiplier: 1.0 + (i as f64 * 0.1),
+                vehicle_type: "SEDAN".to_string(),
+            })
+            .collect();
+
+        let jsons: Vec<String> = estimates
+            .iter()
+            .map(|e| serde_json::to_string(e).unwrap())
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("serialize_batch", count),
+            &estimates,
+            |b, items| {
+                b.iter(|| {
+                    items
+                        .iter()
+                        .map(|e| serde_json::to_string(black_box(e)))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("deserialize_batch", count),
+            &jsons,
+            |b, items| {
+                b.iter(|| {
+                    items
+                        .iter()
+                        .map(|s| serde_json::from_str::<RideEstimate>(black_box(s)))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_set_key_pattern,
+    bench_get_key_pattern,
+    bench_hash_operations,
+    bench_geo_operations,
+    bench_stream_operations,
+    bench_sorted_set_operations
+);
+criterion_main!(benches);

--- a/crates/shared/benches/serialization.rs
+++ b/crates/shared/benches/serialization.rs
@@ -1,0 +1,212 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use serde::{Deserialize, Serialize};
+
+// Representative types matching the crate's data patterns.
+// These mirror the actual structs flowing through Redis commands and API calls.
+
+/// Small struct - similar to redis::types::Point (2 fields)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GeoPoint {
+    lat: f64,
+    lon: f64,
+}
+
+/// Medium struct - similar to callapi::ErrorBody (conditional serialization)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ApiError {
+    #[serde(skip_serializing_if = "String::is_empty")]
+    error_message: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    error_code: String,
+}
+
+/// Large struct - similar to redis::types::RedisSettings (13 fields)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ServiceConfig {
+    host: String,
+    port: u16,
+    cluster_enabled: bool,
+    cluster_urls: Vec<String>,
+    use_legacy_version: bool,
+    pool_size: usize,
+    reconnect_max_attempts: u32,
+    reconnect_delay: u32,
+    default_ttl: u32,
+    default_hash_ttl: u32,
+    stream_read_count: u64,
+    partition: usize,
+    broadcast_channel_capacity: usize,
+}
+
+/// Nested struct - representative domain object flowing through Redis
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DriverLocation {
+    driver_id: String,
+    location: GeoPoint,
+    timestamp: i64,
+    speed: f64,
+    bearing: f64,
+    accuracy: f64,
+    provider: String,
+}
+
+fn sample_geo_point() -> GeoPoint {
+    GeoPoint {
+        lat: 12.9716,
+        lon: 77.5946,
+    }
+}
+
+fn sample_api_error() -> ApiError {
+    ApiError {
+        error_message: "Internal Server Error".to_string(),
+        error_code: "INTERNAL_ERROR".to_string(),
+    }
+}
+
+fn sample_service_config() -> ServiceConfig {
+    ServiceConfig {
+        host: "redis.example.com".to_string(),
+        port: 6379,
+        cluster_enabled: true,
+        cluster_urls: vec![
+            "node1.redis.example.com:6380".to_string(),
+            "node2.redis.example.com:6381".to_string(),
+            "node3.redis.example.com:6382".to_string(),
+        ],
+        use_legacy_version: false,
+        pool_size: 10,
+        reconnect_max_attempts: 5,
+        reconnect_delay: 1000,
+        default_ttl: 3600,
+        default_hash_ttl: 7200,
+        stream_read_count: 100,
+        partition: 0,
+        broadcast_channel_capacity: 32,
+    }
+}
+
+fn sample_driver_location() -> DriverLocation {
+    DriverLocation {
+        driver_id: "driver-550e8400-e29b-41d4-a716-446655440000".to_string(),
+        location: GeoPoint {
+            lat: 12.9716,
+            lon: 77.5946,
+        },
+        timestamp: 1700000000,
+        speed: 45.5,
+        bearing: 180.0,
+        accuracy: 5.0,
+        provider: "gps".to_string(),
+    }
+}
+
+fn bench_serialization(c: &mut Criterion) {
+    let mut group = c.benchmark_group("serialize");
+
+    let point = sample_geo_point();
+    group.bench_function("geo_point", |b| {
+        b.iter(|| serde_json::to_string(black_box(&point)))
+    });
+
+    let error = sample_api_error();
+    group.bench_function("api_error", |b| {
+        b.iter(|| serde_json::to_string(black_box(&error)))
+    });
+
+    // ApiError with empty fields triggers skip_serializing_if
+    let empty_error = ApiError {
+        error_message: String::new(),
+        error_code: String::new(),
+    };
+    group.bench_function("api_error_empty_fields", |b| {
+        b.iter(|| serde_json::to_string(black_box(&empty_error)))
+    });
+
+    let config = sample_service_config();
+    group.bench_function("service_config", |b| {
+        b.iter(|| serde_json::to_string(black_box(&config)))
+    });
+
+    let location = sample_driver_location();
+    group.bench_function("driver_location_nested", |b| {
+        b.iter(|| serde_json::to_string(black_box(&location)))
+    });
+
+    group.finish();
+}
+
+fn bench_deserialization(c: &mut Criterion) {
+    let mut group = c.benchmark_group("deserialize");
+
+    let point_json = serde_json::to_string(&sample_geo_point()).unwrap();
+    group.bench_function("geo_point", |b| {
+        b.iter(|| serde_json::from_str::<GeoPoint>(black_box(&point_json)))
+    });
+
+    let error_json = serde_json::to_string(&sample_api_error()).unwrap();
+    group.bench_function("api_error", |b| {
+        b.iter(|| serde_json::from_str::<ApiError>(black_box(&error_json)))
+    });
+
+    let config_json = serde_json::to_string(&sample_service_config()).unwrap();
+    group.bench_function("service_config", |b| {
+        b.iter(|| serde_json::from_str::<ServiceConfig>(black_box(&config_json)))
+    });
+
+    let location_json = serde_json::to_string(&sample_driver_location()).unwrap();
+    group.bench_function("driver_location_nested", |b| {
+        b.iter(|| serde_json::from_str::<DriverLocation>(black_box(&location_json)))
+    });
+
+    group.finish();
+}
+
+fn bench_batch_deserialization(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batch_deserialize");
+
+    // Simulates the mget_keys pattern where multiple JSON strings are deserialized
+    for count in [10, 50, 100] {
+        let json_strings: Vec<String> = (0..count)
+            .map(|i| {
+                serde_json::to_string(&DriverLocation {
+                    driver_id: format!("driver-{i}"),
+                    location: GeoPoint {
+                        lat: 12.9716 + (i as f64 * 0.001),
+                        lon: 77.5946 + (i as f64 * 0.001),
+                    },
+                    timestamp: 1700000000 + i,
+                    speed: 30.0 + (i as f64),
+                    bearing: (i as f64 * 10.0) % 360.0,
+                    accuracy: 5.0,
+                    provider: "gps".to_string(),
+                })
+                .unwrap()
+            })
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("driver_locations", count),
+            &json_strings,
+            |b, jsons| {
+                b.iter(|| {
+                    jsons
+                        .iter()
+                        .map(|s| serde_json::from_str::<DriverLocation>(black_box(s)))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_serialization,
+    bench_deserialization,
+    bench_batch_deserialization
+);
+criterion_main!(benches);

--- a/crates/shared/benches/utils.rs
+++ b/crates/shared/benches/utils.rs
@@ -1,0 +1,176 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+// Matches the UUID regex used in middleware/utils.rs for path normalization.
+static UUID_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+        .unwrap()
+});
+
+/// Benchmarks UUID regex replacement - the core operation in middleware get_path().
+/// This runs on every incoming HTTP request to normalize paths for metrics.
+fn bench_uuid_regex_replacement(c: &mut Criterion) {
+    let mut group = c.benchmark_group("uuid_regex");
+
+    // Path with single UUID (most common case)
+    let path_single = "/api/v1/driver/550e8400-e29b-41d4-a716-446655440000/location";
+    group.bench_function("single_uuid", |b| {
+        b.iter(|| {
+            UUID_REGEX
+                .replace_all(black_box(path_single), ":id")
+                .into_owned()
+        })
+    });
+
+    // Path with multiple UUIDs
+    let path_multi = "/api/v1/ride/550e8400-e29b-41d4-a716-446655440000/driver/660e8400-e29b-41d4-a716-446655440001";
+    group.bench_function("multiple_uuids", |b| {
+        b.iter(|| {
+            UUID_REGEX
+                .replace_all(black_box(path_multi), ":id")
+                .into_owned()
+        })
+    });
+
+    // Path with no UUID (should short-circuit quickly)
+    let path_none = "/api/v1/health/check";
+    group.bench_function("no_uuid", |b| {
+        b.iter(|| {
+            UUID_REGEX
+                .replace_all(black_box(path_none), ":id")
+                .into_owned()
+        })
+    });
+
+    // Long path with multiple UUIDs
+    let path_long = "/api/v2/org/550e8400-e29b-41d4-a716-446655440000/fleet/660e8400-e29b-41d4-a716-446655440001/driver/770e8400-e29b-41d4-a716-446655440002/trips";
+    group.bench_function("long_path_three_uuids", |b| {
+        b.iter(|| {
+            UUID_REGEX
+                .replace_all(black_box(path_long), ":id")
+                .into_owned()
+        })
+    });
+
+    group.finish();
+}
+
+/// Benchmarks URL decoding - used in get_path() on every incoming request.
+fn bench_url_decoding(c: &mut Criterion) {
+    let mut group = c.benchmark_group("url_decoding");
+
+    // Simple path (no encoding needed - common case)
+    let simple = "/api/v1/driver/location";
+    group.bench_function("no_encoding", |b| {
+        b.iter(|| urlencoding::decode(black_box(simple)).map(|s| s.into_owned()))
+    });
+
+    // Encoded spaces
+    let encoded = "/api/v1/search/New%20York%20City/rides";
+    group.bench_function("encoded_spaces", |b| {
+        b.iter(|| urlencoding::decode(black_box(encoded)).map(|s| s.into_owned()))
+    });
+
+    // Unicode encoded path (non-Latin script)
+    let unicode = "/api/v1/route/%E0%B4%95%E0%B5%8B%E0%B4%9A%E0%B4%BF/to/%E0%B4%A4%E0%B4%BF%E0%B4%B0%E0%B5%81";
+    group.bench_function("unicode_encoded", |b| {
+        b.iter(|| urlencoding::decode(black_box(unicode)).map(|s| s.into_owned()))
+    });
+
+    group.finish();
+}
+
+/// Benchmarks the path parameter replacement pattern used in get_path().
+/// match_info().iter() replaces each captured path segment.
+fn bench_path_param_replacement(c: &mut Criterion) {
+    let mut group = c.benchmark_group("path_param_replace");
+
+    // Single parameter replacement
+    group.bench_function("single_param", |b| {
+        b.iter(|| {
+            let mut path = "/api/v1/driver/driver-john-doe-123/location".to_string();
+            path = path.replace(black_box("driver-john-doe-123"), black_box(":driverId"));
+            path
+        })
+    });
+
+    // Multiple parameter replacements (common in nested routes)
+    group.bench_function("three_params", |b| {
+        b.iter(|| {
+            let mut path =
+                "/api/v1/org/org-acme-456/driver/driver-john-123/ride/ride-789/status".to_string();
+            path = path.replace(black_box("org-acme-456"), black_box(":orgId"));
+            path = path.replace(black_box("driver-john-123"), black_box(":driverId"));
+            path = path.replace(black_box("ride-789"), black_box(":rideId"));
+            path
+        })
+    });
+
+    group.finish();
+}
+
+/// Benchmarks the full get_path pipeline: URL decode -> param replace -> UUID regex.
+fn bench_full_path_normalization(c: &mut Criterion) {
+    let mut group = c.benchmark_group("full_path_normalization");
+
+    // Typical request path through the full pipeline
+    let raw_path = "/api/v1/driver/550e8400-e29b-41d4-a716-446655440000/ride/New%20York";
+    group.bench_function("typical_request", |b| {
+        b.iter(|| {
+            // Step 1: URL decode
+            let mut path = urlencoding::decode(black_box(raw_path))
+                .map(|s| s.into_owned())
+                .unwrap_or_else(|_| raw_path.to_string());
+            // Step 2: UUID regex replacement
+            path = UUID_REGEX.replace_all(&path, ":id").into_owned();
+            path
+        })
+    });
+
+    // Clean path (no encoding, no UUIDs - best case)
+    let clean_path = "/api/v1/health/check";
+    group.bench_function("clean_path", |b| {
+        b.iter(|| {
+            let mut path = urlencoding::decode(black_box(clean_path))
+                .map(|s| s.into_owned())
+                .unwrap_or_else(|_| clean_path.to_string());
+            path = UUID_REGEX.replace_all(&path, ":id").into_owned();
+            path
+        })
+    });
+
+    group.finish();
+}
+
+/// Benchmarks error message formatting patterns used in RedisError and CallAPIError.
+fn bench_error_formatting(c: &mut Criterion) {
+    let mut group = c.benchmark_group("error_formatting");
+
+    let err_detail = "Connection refused: redis.example.com:6379";
+    group.bench_function("redis_error_format", |b| {
+        b.iter(|| format!("Redis Error : {}", black_box(err_detail)))
+    });
+
+    // Error body JSON construction (matches ErrorBody serialization pattern)
+    group.bench_function("error_body_json", |b| {
+        b.iter(|| {
+            serde_json::to_string(&serde_json::json!({
+                "errorMessage": black_box("Connection refused"),
+                "errorCode": black_box("REDIS_CONNECTION_FAILED")
+            }))
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_uuid_regex_replacement,
+    bench_url_decoding,
+    bench_path_param_replacement,
+    bench_full_path_normalization,
+    bench_error_formatting
+);
+criterion_main!(benches);

--- a/crates/shared/src/middleware/incoming_request.rs
+++ b/crates/shared/src/middleware/incoming_request.rs
@@ -65,12 +65,15 @@ where
         Box::pin(async move {
             match fut.await {
                 Ok(response) => {
+                    let resp_headers = get_headers(response.request());
+                    let resp_method = get_method(response.request());
+                    let resp_path = get_path(response.request());
                     calculate_metrics(
                         response.response().error(),
                         response.status(),
-                        get_headers(response.request()),
-                        get_method(response.request()),
-                        get_path(response.request()),
+                        &resp_headers,
+                        &resp_method,
+                        &resp_path,
                         start_time,
                     );
                     Ok(response)
@@ -80,9 +83,9 @@ where
                     calculate_metrics(
                         Some(&err),
                         err_resp_status,
-                        req_headers,
-                        req_method,
-                        req_path,
+                        &req_headers,
+                        &req_method,
+                        &req_path,
                         start_time,
                     );
                     Err(err)

--- a/crates/shared/src/middleware/utils.rs
+++ b/crates/shared/src/middleware/utils.rs
@@ -10,9 +10,14 @@ use crate::incoming_api;
 use crate::tools::prometheus::INCOMING_API;
 use actix_http::StatusCode;
 use actix_web::{Error, HttpRequest};
+use once_cell::sync::Lazy;
 use regex::Regex;
 use tokio::time::Instant;
 use tracing::{error, info};
+
+static UUID_REGEX: Lazy<Option<Regex>> = Lazy::new(|| {
+    Regex::new(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}").ok()
+});
 
 /// Get the path from the HTTP request.
 ///
@@ -25,21 +30,18 @@ use tracing::{error, info};
 /// * `String` - The path string with placeholders for matched info.
 pub fn get_path(request: &HttpRequest) -> String {
     let mut path = urlencoding::decode(request.path())
-        .ok()
-        .map(|s| s.to_string())
-        .unwrap_or(request.path().to_string());
+        .map(|s| s.into_owned())
+        .unwrap_or_else(|_| request.path().to_owned());
 
     request
         .match_info()
         .iter()
         .for_each(|(path_name, path_val)| {
-            path = path.replace(path_val, format!(":{path_name}").as_str());
+            path = path.replace(path_val, &format!(":{path_name}"));
         });
 
-    if let Ok(re) =
-        Regex::new(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
-    {
-        path = re.replace_all(&path, ":id").to_string()
+    if let Some(re) = UUID_REGEX.as_ref() {
+        path = re.replace_all(&path, ":id").into_owned();
     }
 
     path
@@ -54,6 +56,7 @@ pub fn get_path(request: &HttpRequest) -> String {
 ///
 /// # Returns
 /// * `String` - The HTTP method as a string.
+#[inline]
 pub fn get_method(request: &HttpRequest) -> String {
     request.method().to_string()
 }
@@ -67,6 +70,7 @@ pub fn get_method(request: &HttpRequest) -> String {
 ///
 /// # Returns
 /// * `String` - A formatted string representation of the headers.
+#[inline]
 pub fn get_headers(request: &HttpRequest) -> String {
     format!("{:?}", request.headers())
 }
@@ -86,29 +90,23 @@ pub fn get_headers(request: &HttpRequest) -> String {
 pub fn calculate_metrics(
     err_resp: Option<&Error>,
     resp_status: StatusCode,
-    req_headers: String,
-    req_method: String,
-    req_path: String,
+    req_headers: &str,
+    req_method: &str,
+    req_path: &str,
     time: Instant,
 ) {
     if let Some(err_resp) = err_resp {
         let err_resp_code = err_resp.to_string();
         error!(tag = "[INCOMING API - ERROR]", request_method = %req_method, request_path = %req_path, request_headers = req_headers, response_code = err_resp_code, response_status = resp_status.as_str(), latency = format!("{:?}ms", time.elapsed().as_millis()));
         incoming_api!(
-            req_method.as_str(),
-            req_path.as_str(),
+            req_method,
+            req_path,
             resp_status.as_str(),
             err_resp_code.as_str(),
             time
         );
     } else {
         info!(tag = "[INCOMING API]", request_method = %req_method, request_path = %req_path, request_headers = req_headers, response_status = resp_status.as_str(), latency = format!("{:?}ms", time.elapsed().as_millis()));
-        incoming_api!(
-            req_method.as_str(),
-            req_path.as_str(),
-            resp_status.as_str(),
-            "SUCCESS",
-            time
-        );
+        incoming_api!(req_method, req_path, resp_status.as_str(), "SUCCESS", time);
     }
 }

--- a/crates/shared/src/redis/commands.rs
+++ b/crates/shared/src/redis/commands.rs
@@ -413,7 +413,7 @@ impl RedisConnectionPool {
         }
 
         pipeline
-            .all()
+            .all::<RedisValue>()
             .await
             .map_err(|err| RedisError::DeleteFailed(err.to_string()))?;
 
@@ -617,9 +617,9 @@ impl RedisConnectionPool {
                                 .map_err(|err| RedisError::DeserializationError(err.to_string()))?;
                             Ok((key, value))
                         } else {
-                            Err(RedisError::GetHashFieldFailed(format!(
-                                "Unexpected RedisValue encountered"
-                            )))
+                            Err(RedisError::GetHashFieldFailed(
+                                "Unexpected RedisValue encountered".to_owned(),
+                            ))
                         }
                     })
                     .collect::<Result<HashMap<String, T>, RedisError>>()?;
@@ -1559,7 +1559,8 @@ impl RedisConnectionPool {
         F: Into<RedisKey> + Send,
         V: Into<RedisValue> + Send,
     {
-        self.writer_pool
+        let _: RedisValue = self
+            .writer_pool
             .xadd(
                 key,
                 false,
@@ -1615,7 +1616,7 @@ impl RedisConnectionPool {
                                 let mut field_values = Vec::new();
 
                                 // Extract the stream ID, assuming it's the first element in the array.
-                                if let Some(RedisValue::String(id)) = entry_array.get(0) {
+                                if let Some(RedisValue::String(id)) = entry_array.first() {
                                     field_values.push(("stream_id".to_string(), id.to_string()));
                                 }
 

--- a/crates/shared/src/redis/error.rs
+++ b/crates/shared/src/redis/error.rs
@@ -15,7 +15,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ErrorBody {
+    #[serde(skip_serializing_if = "String::is_empty")]
     error_message: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub error_code: String,
 }
 
@@ -61,51 +63,54 @@ pub enum RedisError {
 }
 
 impl RedisError {
+    #[inline]
     fn error_message(&self) -> ErrorBody {
         ErrorBody {
             error_message: self.message(),
-            error_code: self.code(),
+            error_code: self.code().to_owned(),
         }
     }
 
+    #[inline]
     pub fn message(&self) -> String {
         match self {
-            RedisError::SerializationError(err) => err.to_string(),
-            RedisError::DeserializationError(err) => err.to_string(),
+            RedisError::SerializationError(err) => err.clone(),
+            RedisError::DeserializationError(err) => err.clone(),
             RedisError::RedisConnectionError(err) => format!("Redis Connection Error : {err}"),
-            RedisError::TtlFailed(err) => format!("Redis Error : {err}"),
-            RedisError::SetFailed(err) => format!("Redis Error : {err}"),
-            RedisError::SetExFailed(err) => format!("Redis Error : {err}"),
-            RedisError::SetExpiryFailed(err) => format!("Redis Error : {err}"),
-            RedisError::GetFailed(err) => format!("Redis Error : {err}"),
-            RedisError::MGetFailed(err) => format!("Redis Error : {err}"),
-            RedisError::DeleteFailed(err) => format!("Redis Error : {err}"),
-            RedisError::SetHashFieldFailed(err) => format!("Redis Error : {err}"),
-            RedisError::GetHashFieldFailed(err) => format!("Redis Error : {err}"),
-            RedisError::DeleteHashFieldFailed(err) => format!("Redis Error : {err}"),
-            RedisError::DeleteHashFieldsFailed(err) => format!("Redis Error : {err}"),
-            RedisError::RPushFailed(err) => format!("Redis Error : {err}"),
-            RedisError::RPopFailed(err) => format!("Redis Error : {err}"),
-            RedisError::LPopFailed(err) => format!("Redis Error : {err}"),
-            RedisError::LRangeFailed(err) => format!("Redis Error : {err}"),
-            RedisError::LLenFailed(err) => format!("Redis Error : {err}"),
-            RedisError::NotFound(err) => format!("Redis Error : {err}"),
-            RedisError::InvalidRedisEntryId(err) => format!("Redis Error : {err}"),
-            RedisError::SubscribeError(err) => format!("Redis Error : {err}"),
-            RedisError::PublishError(err) => format!("Redis Error : {err}"),
-            RedisError::GeoAddFailed(err) => format!("Redis Error : {err}"),
-            RedisError::ZAddFailed(err) => format!("Redis Error : {err}"),
-            RedisError::ZremrangeByRankFailed(err) => format!("Redis Error : {err}"),
-            RedisError::GeoSearchFailed(err) => format!("Redis Error : {err}"),
-            RedisError::ZCardFailed(err) => format!("Redis Error : {err}"),
-            RedisError::GeoPosFailed(err) => format!("Redis Error : {err}"),
-            RedisError::ZRangeFailed(err) => format!("Redis Error : {err}"),
-            RedisError::XReadFailed(err) => format!("Redis Error : {err}"),
-            _ => "Some Error Occured".to_string(),
+            RedisError::TtlFailed(err)
+            | RedisError::SetFailed(err)
+            | RedisError::SetExFailed(err)
+            | RedisError::SetExpiryFailed(err)
+            | RedisError::GetFailed(err)
+            | RedisError::MGetFailed(err)
+            | RedisError::DeleteFailed(err)
+            | RedisError::SetHashFieldFailed(err)
+            | RedisError::GetHashFieldFailed(err)
+            | RedisError::DeleteHashFieldFailed(err)
+            | RedisError::DeleteHashFieldsFailed(err)
+            | RedisError::RPushFailed(err)
+            | RedisError::RPopFailed(err)
+            | RedisError::LPopFailed(err)
+            | RedisError::LRangeFailed(err)
+            | RedisError::LLenFailed(err)
+            | RedisError::NotFound(err)
+            | RedisError::InvalidRedisEntryId(err)
+            | RedisError::SubscribeError(err)
+            | RedisError::PublishError(err)
+            | RedisError::GeoAddFailed(err)
+            | RedisError::ZAddFailed(err)
+            | RedisError::ZremrangeByRankFailed(err)
+            | RedisError::GeoSearchFailed(err)
+            | RedisError::ZCardFailed(err)
+            | RedisError::GeoPosFailed(err)
+            | RedisError::ZRangeFailed(err)
+            | RedisError::XReadFailed(err) => format!("Redis Error : {err}"),
+            _ => "Some Error Occured".to_owned(),
         }
     }
 
-    fn code(&self) -> String {
+    #[inline]
+    fn code(&self) -> &'static str {
         match self {
             RedisError::SerializationError(_) => "SERIALIZATION_ERROR",
             RedisError::DeserializationError(_) => "DESERIALIZATION_ERROR",
@@ -145,17 +150,18 @@ impl RedisError {
             RedisError::ClusterShardsToNodeError(_) => "CLUSTER_SHARDS_TO_NODE_ERROR",
             RedisError::ClusterKeySlotError(_) => "CLUSTER_KEY_SLOT_ERROR",
         }
-        .to_string()
     }
 }
 
 impl ResponseError for RedisError {
+    #[inline]
     fn error_response(&self) -> HttpResponse {
         HttpResponse::build(self.status_code())
             .insert_header(ContentType::json())
             .json(self.error_message())
     }
 
+    #[inline]
     fn status_code(&self) -> StatusCode {
         match self {
             RedisError::SerializationError(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/shared/src/redis/types.rs
+++ b/crates/shared/src/redis/types.rs
@@ -13,17 +13,12 @@ use fred::{
     prelude::EventInterface,
     types::{ConnectHandle, Message, ReconnectPolicy, RedisConfig, RedisValue},
 };
-use log::info;
 // use futures::{channel::mpsc::{self, UnboundedReceiver, UnboundedSender}, SinkExt};
 use super::error::RedisError;
 use serde::{de::DeserializeOwned, Deserialize};
+use tokio::sync::broadcast::Receiver;
 use tokio::sync::mpsc;
-use tokio::sync::{
-    broadcast::Receiver,
-    mpsc::{UnboundedReceiver, UnboundedSender},
-};
 use tracing::error;
-use tracing::*;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Point {
@@ -117,6 +112,7 @@ pub struct RedisClient {
 
 impl std::ops::Deref for RedisClient {
     type Target = fred::prelude::RedisClient;
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.client
     }
@@ -245,8 +241,10 @@ impl RedisConnectionPool {
             conf.reconnect_delay,
         );
 
-        let mut performance_config = fred::types::PerformanceConfig::default();
-        performance_config.broadcast_channel_capacity = conf.broadcast_channel_capacity;
+        let performance_config = fred::types::PerformanceConfig {
+            broadcast_channel_capacity: conf.broadcast_channel_capacity,
+            ..Default::default()
+        };
 
         let pool = fred::prelude::RedisPool::new(
             config,
@@ -286,10 +284,7 @@ impl RedisConnectionPool {
     where
         T: DeserializeOwned + Send + 'static,
     {
-        let (tx, mut rx): (
-            UnboundedSender<(String, T, DateTime<Utc>)>,
-            UnboundedReceiver<(String, T, DateTime<Utc>)>,
-        ) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::unbounded_channel();
 
         let redis_connection = self.reader_pool.next();
         redis_connection.subscribe(channel).await.map_err(|e| {
@@ -303,10 +298,7 @@ impl RedisConnectionPool {
             loop {
                 let res = message_stream.recv().await;
                 match res {
-                    Err(err) => error!(
-                        "Error in receiving message from Redis, err : {}",
-                        err.to_string()
-                    ),
+                    Err(err) => error!("Error in receiving message from Redis, err : {}", err),
                     Ok(msg) => {
                         let channel_name = msg.channel.to_string();
                         match &msg.value {
@@ -344,10 +336,7 @@ impl RedisConnectionPool {
         &self,
         channel: &str,
     ) -> Result<mpsc::UnboundedReceiver<(String, String)>, RedisError> {
-        let (tx, mut rx): (
-            UnboundedSender<(String, String)>,
-            UnboundedReceiver<(String, String)>,
-        ) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::unbounded_channel();
 
         let redis_connection = self.reader_pool.next();
         redis_connection.subscribe(channel).await.map_err(|e| {
@@ -361,10 +350,7 @@ impl RedisConnectionPool {
             loop {
                 let res = message_stream.recv().await;
                 match res {
-                    Err(err) => error!(
-                        "Error in receiving message from Redis, err : {}",
-                        err.to_string()
-                    ),
+                    Err(err) => error!("Error in receiving message from Redis, err : {}", err),
                     Ok(msg) => {
                         let channel_name = msg.channel.to_string();
                         match &msg.value {

--- a/crates/shared/src/tools/aws.rs
+++ b/crates/shared/src/tools/aws.rs
@@ -38,7 +38,9 @@ impl AWSClient {
     /// 5. EKS pod identity (when running in EKS)
     pub async fn new() -> Result<Self, AWSError> {
         // Load configuration from environment, credentials file, and instance profile
-        let config = aws_config::from_env().load().await;
+        let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .load()
+            .await;
 
         let client = Client::new(&config);
 
@@ -110,17 +112,17 @@ impl AWSClient {
                 ))
             })?;
 
-            if let Some(contents) = response.contents.to_owned() {
+            if let Some(contents) = &response.contents {
                 for object in contents {
                     if let Some(key) = object.key() {
-                        objects.push(key.to_string());
+                        objects.push(key.to_owned());
                     }
                 }
             }
 
             // Check if there are more objects to fetch
             if let Some(next_continuation_token) = response.next_continuation_token() {
-                continuation_token = Some(next_continuation_token.to_string());
+                continuation_token = Some(next_continuation_token.to_owned());
             } else {
                 break;
             }

--- a/crates/shared/src/tools/callapi.rs
+++ b/crates/shared/src/tools/callapi.rs
@@ -20,10 +20,15 @@ use std::{convert, fmt::Debug, pin::Pin};
 use std::{future::Future, str::FromStr};
 use tracing::{error, info};
 
+type ErrorHandler<E> =
+    Box<dyn Fn(Response) -> Pin<Box<dyn Future<Output = E> + Send>> + Send + Sync>;
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ErrorBody {
+    #[serde(skip_serializing_if = "String::is_empty")]
     error_message: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub error_code: String,
 }
 
@@ -37,22 +42,24 @@ pub enum CallAPIError {
 }
 
 impl CallAPIError {
+    #[inline]
     fn error_message(&self) -> ErrorBody {
         ErrorBody {
             error_message: self.message(),
-            error_code: self.code(),
+            error_code: self.code().to_owned(),
         }
     }
 
+    #[inline]
     pub fn message(&self) -> String {
         match self {
-            CallAPIError::InternalError(err) => err.to_string(),
-            CallAPIError::InvalidRequest(err) => err.to_string(),
-            _ => "Some Error Occured".to_string(),
+            CallAPIError::InternalError(err) | CallAPIError::InvalidRequest(err) => err.clone(),
+            _ => "Some Error Occured".to_owned(),
         }
     }
 
-    fn code(&self) -> String {
+    #[inline]
+    fn code(&self) -> &'static str {
         match self {
             CallAPIError::InternalError(_) => "INTERNAL_ERROR",
             CallAPIError::InvalidRequest(_) => "INVALID_REQUEST",
@@ -60,17 +67,18 @@ impl CallAPIError {
             CallAPIError::SerializationError(_) => "SERIALIZATION_ERROR",
             CallAPIError::DeserializationError(_) => "DESERIALIZATION_ERROR",
         }
-        .to_string()
     }
 }
 
 impl ResponseError for CallAPIError {
+    #[inline]
     fn error_response(&self) -> HttpResponse {
         HttpResponse::build(self.status_code())
             .insert_header(ContentType::json())
             .json(self.error_message())
     }
 
+    #[inline]
     fn status_code(&self) -> StatusCode {
         match self {
             CallAPIError::InternalError(_) => StatusCode::INTERNAL_SERVER_ERROR,
@@ -186,7 +194,7 @@ where
         Err(err) => err
             .status()
             .map(|status| status.to_string())
-            .unwrap_or("UNKNOWN".to_string()),
+            .unwrap_or_else(|| "UNKNOWN".to_owned()),
     };
 
     call_external_api!(
@@ -238,13 +246,13 @@ where
 /// * `headers` - A vector of header key-value pairs to include in the request.
 /// * `body` - An optional request body. If provided, it will be serialized to JSON.
 /// * `error_handler` - A boxed function that takes a `Response` and returns an `CallAPIError`.
-///                     This is used to convert non-successful responses into appropriate errors.
+///   This is used to convert non-successful responses into appropriate errors.
 ///
 /// # Returns
 ///
 /// * `Ok(T)` if the API call succeeds and the response can be deserialized into type `T`.
 /// * `Err(CallAPIError)` if there's any error during the API call, serialization, deserialization,
-///                   or if the response status indicates an error.
+///   or if the response status indicates an error.
 ///
 /// # Type Parameters
 ///
@@ -274,7 +282,7 @@ pub async fn call_api_unwrapping_error<T, U, E>(
     headers: Vec<(&str, &str)>,
     body: Option<U>,
     service: Option<&str>,
-    error_handler: Box<dyn Fn(Response) -> Pin<Box<dyn Future<Output = E> + Send>> + Send + Sync>,
+    error_handler: ErrorHandler<E>,
 ) -> Result<T, E>
 where
     T: DeserializeOwned + 'static,
@@ -303,7 +311,7 @@ pub async fn call_api_with_client<T, U, E>(
     headers: Vec<(&str, &str)>,
     body: Option<U>,
     service: Option<&str>,
-    error_handler: Box<dyn Fn(Response) -> Pin<Box<dyn Future<Output = E> + Send>> + Send + Sync>,
+    error_handler: ErrorHandler<E>,
 ) -> Result<T, E>
 where
     T: DeserializeOwned + 'static,
@@ -349,7 +357,7 @@ where
         Err(err) => err
             .status()
             .map(|status| status.to_string())
-            .unwrap_or("UNKNOWN".to_string()),
+            .unwrap_or_else(|| "UNKNOWN".to_owned()),
     };
 
     call_external_api!(

--- a/crates/shared/src/tools/cloud_storage.rs
+++ b/crates/shared/src/tools/cloud_storage.rs
@@ -22,11 +22,15 @@ impl FromStr for CloudProvider {
     /// Supported values:
     /// - AWS: "aws", "s3"
     /// - GCS: "gcs", "gcp", "google"
+    #[inline]
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_uppercase().as_str() {
             "AWS" | "S3" => Ok(CloudProvider::AWS),
             "GCS" | "GCP" | "GOOGLE" => Ok(CloudProvider::GCS),
-            _ => Err(format!("Invalid cloud provider: '{}'. Supported values: aws, s3, gcs, gcp, google", s)),
+            _ => Err(format!(
+                "Invalid cloud provider: '{}'. Supported values: aws, s3, gcs, gcp, google",
+                s
+            )),
         }
     }
 }
@@ -34,6 +38,7 @@ impl FromStr for CloudProvider {
 impl CloudProvider {
     /// Parse from string (case-insensitive) - returns Option for backward compatibility
     #[deprecated(note = "Use std::str::FromStr::from_str or parse() instead")]
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         s.parse().ok()
     }
@@ -176,12 +181,10 @@ pub async fn get_files_in_directory_from_str(
     bucket: &str,
     prefix: &str,
 ) -> Result<HashMap<String, Vec<u8>>, CloudStorageError> {
-    let provider = provider_str
-        .parse::<CloudProvider>()
-        .map_err(|e| {
-            error_stack::Report::new(CloudStorageError::InvalidProvider(provider_str.to_string()))
-                .attach_printable(e)
-        })?;
+    let provider = provider_str.parse::<CloudProvider>().map_err(|e| {
+        error_stack::Report::new(CloudStorageError::InvalidProvider(provider_str.to_string()))
+            .attach_printable(e)
+    })?;
 
     get_files_in_directory(provider, bucket, prefix).await
 }

--- a/crates/shared/src/tools/logger.rs
+++ b/crates/shared/src/tools/logger.rs
@@ -26,6 +26,7 @@ pub enum LogLevel {
 }
 
 impl From<LogLevel> for LevelFilter {
+    #[inline]
     fn from(log_level: LogLevel) -> Self {
         match log_level {
             LogLevel::TRACE => LevelFilter::TRACE,
@@ -75,7 +76,7 @@ pub struct LoggerConfig {
 pub fn setup_tracing(logger_cfg: LoggerConfig) -> WorkerGuard {
     LogTracer::init().expect("Failed to setup logger");
 
-    let app_name = concat!(env!("CARGO_PKG_NAME"), "-", env!("CARGO_PKG_VERSION")).to_string();
+    let app_name = concat!(env!("CARGO_PKG_NAME"), "-", env!("CARGO_PKG_VERSION"));
 
     let (non_blocking_console_writer, guard) = tracing_appender::non_blocking(std::io::stdout());
 

--- a/crates/shared/src/tools/prometheus.rs
+++ b/crates/shared/src/tools/prometheus.rs
@@ -60,7 +60,7 @@ pub static INCOMING_API: once_cell::sync::Lazy<HistogramVec> = once_cell::sync::
 macro_rules! incoming_api {
     ($method:expr, $endpoint:expr, $status:expr, $code:expr, $start:expr) => {
         let duration = $start.elapsed().as_secs_f64();
-        let version = std::env::var("DEPLOYMENT_VERSION").unwrap_or("DEV".to_string());
+        let version = std::env::var("DEPLOYMENT_VERSION").unwrap_or_else(|_| "DEV".to_owned());
         INCOMING_API
             .with_label_values(&[$method, $endpoint, $status, $code, version.as_str()])
             .observe(duration);
@@ -91,7 +91,7 @@ macro_rules! call_external_api {
 macro_rules! termination {
     ($type_:expr, $start:expr) => {
         let duration = $start.elapsed().as_secs_f64();
-        let version = std::env::var("DEPLOYMENT_VERSION").unwrap_or("DEV".to_string());
+        let version = std::env::var("DEPLOYMENT_VERSION").unwrap_or_else(|_| "DEV".to_owned());
         TERMINATION
             .with_label_values(&[$type_, version.as_str()])
             .observe(duration);

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -71,8 +71,8 @@ async fn test_list_objects_gcs() {
     use shared::tools::gcs::GCSClient;
     use std::env;
 
-    let bucket = env::var("GCS_TEST_BUCKET")
-        .unwrap_or_else(|_| "beckn-image-gcs-bucket".to_string());
+    let bucket =
+        env::var("GCS_TEST_BUCKET").unwrap_or_else(|_| "beckn-image-gcs-bucket".to_string());
     let prefix = "";
 
     let gcs_client = match GCSClient::new().await {
@@ -82,11 +82,14 @@ async fn test_list_objects_gcs() {
             eprintln!("\nTo authenticate with GCS, you need to:");
             eprintln!("  1. Set GOOGLE_APPLICATION_CREDENTIALS environment variable to path of service account JSON, OR");
             eprintln!("  2. Run: gcloud auth application-default login");
-            eprintln!("  3. Ensure you have proper permissions to access bucket: {}", bucket);
+            eprintln!(
+                "  3. Ensure you have proper permissions to access bucket: {}",
+                bucket
+            );
             panic!("GCS authentication failed");
         }
     };
-    
+
     let objects = match gcs_client.list_objects_gcs(&bucket, prefix).await {
         Ok(objs) => objs,
         Err(e) => {
@@ -111,9 +114,9 @@ async fn test_download_file_gcs() {
     use shared::tools::gcs::{get_file_from_gcs, GCSClient};
     use std::env;
 
-    let bucket = env::var("GCS_TEST_BUCKET")
-        .unwrap_or_else(|_| "beckn-image-gcs-bucket".to_string());
-    
+    let bucket =
+        env::var("GCS_TEST_BUCKET").unwrap_or_else(|_| "beckn-image-gcs-bucket".to_string());
+
     // First, let's list objects to find a file to download
     let gcs_client = match GCSClient::new().await {
         Ok(client) => client,
@@ -125,7 +128,7 @@ async fn test_download_file_gcs() {
             panic!("GCS authentication failed");
         }
     };
-    
+
     let objects = match gcs_client.list_objects_gcs(&bucket, "").await {
         Ok(objs) => objs,
         Err(e) => {
@@ -133,7 +136,7 @@ async fn test_download_file_gcs() {
             panic!("Failed to list GCS objects");
         }
     };
-    
+
     if objects.is_empty() {
         println!("No objects found in bucket: {}", bucket);
         return;
@@ -154,9 +157,11 @@ async fn test_download_file_gcs() {
 
     println!(
         "Successfully fetched file from GCS: {}/{} => {} bytes",
-        bucket, key, data.len()
+        bucket,
+        key,
+        data.len()
     );
-    
+
     // Try to display as string if it's text, otherwise show first few bytes
     if let Ok(text) = String::from_utf8(data.clone()) {
         let preview = if text.len() > 200 {
@@ -179,11 +184,14 @@ async fn test_download_files_from_directory_gcs() {
     use shared::tools::gcs::get_files_in_directory_from_gcs;
     use std::env;
 
-    let bucket = env::var("GCS_TEST_BUCKET")
-        .unwrap_or_else(|_| "beckn-image-gcs-bucket".to_string());
+    let bucket =
+        env::var("GCS_TEST_BUCKET").unwrap_or_else(|_| "beckn-image-gcs-bucket".to_string());
     let prefix = ""; // Empty prefix means root of bucket
 
-    println!("Downloading files from GCS bucket: {} with prefix: '{}'", bucket, prefix);
+    println!(
+        "Downloading files from GCS bucket: {} with prefix: '{}'",
+        bucket, prefix
+    );
 
     // Download the files
     let data = match get_files_in_directory_from_gcs(&bucket, prefix).await {
@@ -197,15 +205,16 @@ async fn test_download_files_from_directory_gcs() {
         }
     };
 
-    println!("Successfully fetched {} files from GCS bucket: {}", data.len(), bucket);
-    
+    println!(
+        "Successfully fetched {} files from GCS bucket: {}",
+        data.len(),
+        bucket
+    );
+
     for (key, file_data) in data.iter().take(5) {
-        println!(
-            "  File: {} => {} bytes",
-            key, file_data.len()
-        );
+        println!("  File: {} => {} bytes", key, file_data.len());
     }
-    
+
     if data.len() > 5 {
         println!("  ... and {} more files", data.len() - 5);
     }
@@ -217,8 +226,8 @@ async fn test_cloud_storage_wrapper_gcs() {
     use shared::tools::cloud_storage::{get_files_in_directory, CloudProvider};
     use std::env;
 
-    let bucket = env::var("GCS_TEST_BUCKET")
-        .unwrap_or_else(|_| "beckn-image-gcs-bucket".to_string());
+    let bucket =
+        env::var("GCS_TEST_BUCKET").unwrap_or_else(|_| "beckn-image-gcs-bucket".to_string());
     let prefix = "";
 
     println!("Testing cloud storage wrapper with GCS provider");
@@ -231,12 +240,15 @@ async fn test_cloud_storage_wrapper_gcs() {
         }
     };
 
-    println!("Successfully fetched {} files using cloud storage wrapper (GCS)", files.len());
-    
+    println!(
+        "Successfully fetched {} files using cloud storage wrapper (GCS)",
+        files.len()
+    );
+
     for (key, file_data) in files.iter().take(5) {
         println!("  File: {} => {} bytes", key, file_data.len());
     }
-    
+
     if files.len() > 5 {
         println!("  ... and {} more files", files.len() - 5);
     }
@@ -248,8 +260,8 @@ async fn test_cloud_storage_wrapper_from_str() {
     use shared::tools::cloud_storage::get_files_in_directory_from_str;
     use std::env;
 
-    let bucket = env::var("GCS_TEST_BUCKET")
-        .unwrap_or_else(|_| "beckn-image-gcs-bucket".to_string());
+    let bucket =
+        env::var("GCS_TEST_BUCKET").unwrap_or_else(|_| "beckn-image-gcs-bucket".to_string());
     let prefix = "";
 
     println!("Testing cloud storage wrapper with string provider 'gcs'");
@@ -262,8 +274,11 @@ async fn test_cloud_storage_wrapper_from_str() {
         }
     };
 
-    println!("Successfully fetched {} files using string-based wrapper", files.len());
-    
+    println!(
+        "Successfully fetched {} files using string-based wrapper",
+        files.len()
+    );
+
     // Test invalid provider
     let result = get_files_in_directory_from_str("invalid", &bucket, prefix).await;
     assert!(result.is_err(), "Should fail with invalid provider");


### PR DESCRIPTION
## Problem
The shared-kernel-rs library had several performance inefficiencies and code quality issues: unnecessary string allocations in error handling, uncompiled regex patterns evaluated on every call, redundant `format!()` wrappers, deprecated AWS SDK usage, and missing inline hints on hot-path utility functions. Additionally, there were no performance benchmarks to catch regressions.

## Solution
### Performance Optimizations
- **Lazy-compiled UUID regex** via `once_cell::sync::Lazy` in middleware utils (eliminates re-compilation per request)
- **`&'static str` for error codes** — `code()` returns static strings instead of allocating `String` on every error
- **`#[inline]` hints** on hot-path functions: `get_method()`, `get_headers()`, `Deref` impl, error helpers
- **Reduced allocations** — `.first()` instead of `.get(0)`, `to_owned()` over `to_string()` for `&str`, direct string clones instead of format wrappers
- **`#[serde(skip_serializing_if)]`** to avoid serializing empty optional fields

### Code Quality
- **Updated deprecated AWS SDK** — `aws_config::from_env()` → `aws_config::defaults(BehaviorVersion::latest())`
- **Removed unused imports** (`log::info`, `tracing::*`, `UnboundedReceiver`, `UnboundedSender`)
- **Proc macro improvement** — `measure_duration` now preserves function attributes (`#[allow(...)]`, `#[cfg(...)]`)
- **Extracted `ErrorHandler<E>` type alias** for readability in callapi module
- **Middleware refactor** — extracts headers/method/path into locals before passing by reference

### Benchmarks
- **Added criterion benchmarks** for Redis serialization patterns, serde serialization/deserialization, and middleware path normalization/URL decoding/error formatting

## Testing
- [x] `cargo build` passes
- [x] `cargo clippy` clean
- [x] `cargo test` passes
- [ ] Run benchmarks: `cargo bench`
- [ ] Verify downstream services compile against updated shared-kernel

## Impact
- **17 files changed** (4 new benchmark files, 13 modified source files)
- **Risk: LOW-MEDIUM** — this is a shared library; changes affect all downstream Rust services
- Key hot-path improvements: regex compilation (once vs per-request), error code allocation elimination, inline hints
- New benchmark suite enables future performance regression detection